### PR TITLE
fixed datetime obj parsing from str for tz handling

### DIFF
--- a/skodaconnect/dashboard.py
+++ b/skodaconnect/dashboard.py
@@ -2,6 +2,7 @@
 # Thanks to molobrakos
 
 import logging
+from datetime import datetime
 from skodaconnect.utilities import camel2slug
 
 _LOGGER = logging.getLogger(__name__)
@@ -291,7 +292,7 @@ class Position(Instrument):
         return (
             state.get("lat", "?"),
             state.get("lng", "?"),
-            str(ts.astimezone(tz=None)) if ts else None,
+            str(datetime.strptime(ts,'%Y-%m-%dT%H:%M:%SZ').astimezone(tz=None)) if ts else None,
         )
 
 

--- a/skodaconnect/vehicle.py
+++ b/skodaconnect/vehicle.py
@@ -1119,7 +1119,7 @@ class Vehicle:
     def last_connected(self):
         """Return when vehicle was last connected to connect servers."""
         last_connected_utc = self.attrs.get('StoredVehicleDataResponse').get('vehicleData').get('data')[0].get('field')[0].get('tsCarSentUtc')
-        last_connected = last_connected_utc.replace(tzinfo=timezone.utc).astimezone(tz=None)
+        last_connected = datetime.strptime(last_connected_utc,'%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone.utc).astimezone(tz=None)
         return last_connected.strftime('%Y-%m-%d %H:%M:%S')
 
     @property
@@ -1509,7 +1509,7 @@ class Vehicle:
     def parking_time(self):
         """Return timestamp of last parking time."""
         parkTime_utc = self.attrs.get('findCarResponse', {}).get('parkingTimeUTC', 'Unknown')
-        parkTime = parkTime_utc.replace(tzinfo=timezone.utc).astimezone(tz=None)
+        parkTime = datetime.strptime(parkTime_utc,'%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone.utc).astimezone(tz=None)
         return parkTime.strftime('%Y-%m-%d %H:%M:%S')
 
     @property


### PR DESCRIPTION
Running the example.py throws errors:
vehicle.py:
TypeError: replace() takes no keyword arguments
dashboard.py:
AttributeError: 'str' object has no attribute 'astimezone'

Both were related to handling date values in string format as datetime object (e.g. the replace function matches the build-in for str).
I fixed it by parsing the str format with datetime.strptime().