### PR TITLE
Fix for Enyaq electric_climatisation

### DIFF
--- a/skodaconnect/vehicle.py
+++ b/skodaconnect/vehicle.py
@@ -1840,7 +1840,7 @@ class Vehicle:
             status = self.attrs.get('climater', {}).get('status', {}).get('climatisationStatusData', {}).get('climatisationState', {}).get('content', '')
             if status in ['heating', 'cooling', 'on'] and climatisation_type == 'electric':
                 return True
-        elif self.attrs.get('airConditioning', {}).get('state', False) in ['ON', 'On', 'on']:
+        elif self.attrs.get('airConditioning', {}).get('state', False) in ['ON', 'On', 'on', 'Heating']:
             return True
         return False
 


### PR DESCRIPTION
Response can contain 'Heating' for 'state':

INFO:skodaconnect.connection:Returning with data {'airConditioning': {'remainingTimeToReachTargetTemperatureInSeconds': 1800, 'state': 'Heating', 'trigger': 'MANUAL', 'windowsHeatingStatuses': [{'windowLocation': 'Front', 'state': 'Off'}, {'windowLocation': 'Rear', 'state': 'Off'}], 'seatHeatingSupport': {'frontLeftAvailable': True, 'frontRightAvailable': True, 'rearLeftAvailable': False, 'rearRightAvailable': False}}, 'airConditioningSettings': {'targetTemperatureInKelvin': 295.65, 'temperatureConversionTableUsed': 'CELSIUS_KELVIN', 'airConditioningAtUnlock': True, 'windowHeatingEnabled': False, 'zonesSettings': {'frontLeftEnabled': False, 'frontRightEnabled': False}}}
