### PR TITLE
Remove pytest-asyncio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ aiohttp
 beautifulsoup4
 cryptography
 lxml
-pytest-asyncio
 pyjwt


### PR DESCRIPTION
`pytest-asyncio` is not a runtime-requirement. It's just for testing.