### PR TITLE
Fixed weekday bug in vehicle.py

### DIFF
--- a/skodaconnect/vehicle.py
+++ b/skodaconnect/vehicle.py
@@ -625,7 +625,7 @@ class Vehicle:
                             days = schedule.get('days', 'nnnnnnn')
                             for num in range(0, 7):
                                 if days[num] == 'y':
-                                    data['timersSettings']['timers'][index]['recurringOn'].append(days[num])
+                                    data['timersSettings']['timers'][index]['recurringOn'].append(weekdays[num])
                         else:
                             data['timersSettings']['timers'][index]['type'] = 'ONE_OFF'
                             data['timersSettings']['timers'][index]['date'] = schedule.get('date')


### PR DESCRIPTION
Line 628 contained incorrect reference to day, renamed it to weekdays. Should now return the correct schedule array.

I have not been able to test any of this, since I don't know how to incorporate the code edit in my home assistant instance.