### PR TITLE
Fix TypeError in Vehicle.last_connected

### DIFF
--- a/skodaconnect/vehicle.py
+++ b/skodaconnect/vehicle.py
@@ -1538,8 +1538,10 @@ class Vehicle:
             last_connected_utc = self.attrs.get('vehicle_remote', {}).get('capturedAt', None)
             if isinstance(last_connected_utc, datetime):
                 last_connected = last_connected_utc.astimezone().replace(tzinfo=None)
-            else:
+            elif isinstance(last_connected_utc, str):
                 last_connected = datetime.strptime(last_connected_utc,'%Y-%m-%dT%H:%M:%S.%fZ').astimezone().replace(tzinfo=None).replace(microsecond=0)
+            else:
+                return None
         return last_connected.isoformat()
 
     @property


### PR DESCRIPTION
Fixes #70

```
File "/usr/local/lib/python3.10/site-packages/skodaconnect/dashboard.py", line 127, in state val = super().state
File "/usr/local/lib/python3.10/site-packages/skodaconnect/dashboard.py", line 58, in state if hasattr(self.vehicle, self.attr):
File "/usr/local/lib/python3.10/site-packages/skodaconnect/vehicle.py", line 1542, in last_connected last_connected = datetime.strptime(last_connected_utc,'%Y-%m-%dT%H:%M:%S.%fZ').astimezone().replace(tzinfo=None).replace(microsecond=0) TypeError: strptime() argument 1 must be str, not None
```